### PR TITLE
added blog article contents & link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,22 @@
 # SparkGitHubBot
-It listens for Commits (push event) &amp; Comments(commit comment event) on a particular repo and posts the details into a Spark room.
 
-You will also need to set up a github webhook for the specific repo.
+To help with the understanding of bots, we put together a walkthrough of a Github to Spark integration – official integrations with Github exist now, and will be expanded, so this is purely for demonstration purposes (but you can use the code now if you want an integration you can more directly control).
 
-See links below for more details:
+The bot listens for commits and comments on a particular repo, and then posts the details into a group or team room. The below parameters will be included in the message to a Spark room:
 
-https://developer.github.com/webhooks/
+* Author Name
+* Committer Name
+* Pusher Name
+* Commit id
+* Commit time
+* Repository
+* Link to the Commit
+* Comment
+* Comment Link
+* Comment User
+* Repo
+* Commit id
 
-https://developer.github.com/v3/repos/hooks/
+To build this bot, check this [step by step guide](https://developer.ciscospark.com/blog/blog-details-8228.html).
 
-https://developer.github.com/v3/activity/events/types/
+


### PR DESCRIPTION
Now that the blog entry is published, I propose we integrate it into the Readme.md for developers who would be pointed to the github repo, and not starting from the blog entry.
